### PR TITLE
Bump GitHub Actions off deprecated Node 20

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,10 +23,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.x"
           cache: "npm"
@@ -41,10 +41,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.x"
           cache: "npm"
@@ -56,7 +56,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: "coverage-report"
           path: "coverage/"
@@ -67,22 +67,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v3.2.1
+        uses: gittools/actions/gitversion/setup@v4.7.0
 
       - name: Determine Version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v3.2.1
+        uses: gittools/actions/gitversion/execute@v4.7.0
         with:
-          useConfigFile: true
           configFilePath: GitVersion.yml
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.x"
           cache: "npm"
@@ -97,7 +96,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: "dist"
           path: "./dist"
@@ -119,14 +118,14 @@ jobs:
       deployments: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: "dist"
           path: "./dist"
 
       - name: Deploy preview to Netlify
         id: netlify
-        uses: nwtgck/actions-netlify@v3.0
+        uses: nwtgck/actions-netlify@v4.0.0
         with:
           publish-dir: "./dist"
           production-deploy: false
@@ -149,14 +148,14 @@ jobs:
       deployments: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: "dist"
           path: "./dist"
 
       - name: Deploy to Netlify
         id: netlify
-        uses: nwtgck/actions-netlify@v3.0
+        uses: nwtgck/actions-netlify@v4.0.0
         with:
           publish-dir: "./dist"
           production-deploy: true


### PR DESCRIPTION
## What
Bump all GitHub Actions to majors that run on Node 24, clearing the "Node.js 20 is deprecated" warnings emitted on every workflow run.

## Changes
- `actions/checkout`, `actions/setup-node`, `actions/upload-artifact` → **v7**
- `actions/download-artifact` → **v8**
- `gittools/actions` (gitversion setup + execute) → **v4.7.0**
- `nwtgck/actions-netlify` → **v4.0.0**
- Drop the `useConfigFile` input (removed in gittools v4; `configFilePath` alone now selects the config)

## Compatibility
Verified against the same bump already shipped in `qr-code-builder`: gittools v4 still exposes the `fullSemVer` output and honors the existing v6-style `GitVersion.yml`; actions-netlify v4 keeps every input in use. Version resolution confirmed unaffected.

🤖 Opened with [Claude Code](https://claude.com/claude-code)